### PR TITLE
WooCommerce Registration Support

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -154,6 +154,11 @@ class Plugin {
 			new \ZeroSpam\Modules\MailchimpForWP\MailchimpForWP();
 		}
 
+		// Zero Spam WooCommerce module.
+		if ( is_plugin_active( 'woocommerce/woocommerce.php' ) ) {
+			new \ZeroSpam\Modules\WooCommerce\WooCommerce();
+		}
+
 		// Debug module.
 		new \ZeroSpam\Modules\Debug();
 	}

--- a/modules/davidwalsh/assets/js/davidwalsh.js
+++ b/modules/davidwalsh/assets/js/davidwalsh.js
@@ -26,16 +26,20 @@
       // Hidden input isn't present, add it.
       $(
         '<input type="hidden" name="zerospam_david_walsh_key" value="' +
-        ZeroSpamDavidWalsh.key +
+          ZeroSpamDavidWalsh.key +
           '" />'
       ).appendTo(this);
     }
   };
 
-  $(function() {
-    var selectors = '#commentform, #registerform, .wpforms-form, .wpcf7-form, .frm-fluent-form, #loginform, .woocommerce-form-login, .mepr-signup-form, .mc4wp-form, #mepr_loginform';
-    if (typeof ZeroSpamDavidWalsh.selectors != "undefined" && ZeroSpamDavidWalsh.selectors ) {
-      selectors += ',' + ZeroSpamDavidWalsh.selectors
+  $(function () {
+    var selectors =
+      "#commentform, #registerform, .wpforms-form, .wpcf7-form, .frm-fluent-form, #loginform, .mepr-signup-form, .mc4wp-form, #mepr_loginform, .woocommerce-form-register";
+    if (
+      typeof ZeroSpamDavidWalsh.selectors != "undefined" &&
+      ZeroSpamDavidWalsh.selectors
+    ) {
+      selectors += "," + ZeroSpamDavidWalsh.selectors;
     }
 
     jQuery(selectors).ZeroSpamDavidWalsh();

--- a/modules/davidwalsh/class-davidwalsh.php
+++ b/modules/davidwalsh/class-davidwalsh.php
@@ -47,6 +47,7 @@ class DavidWalsh {
 			add_action( 'zerospam_login_scripts', array( $this, 'enqueue_script' ) );
 			add_action( 'zerospam_mailchimp4wp_scripts', array( $this, 'enqueue_script' ) );
 			add_action( 'zerospam_memberpress_login_scripts', array( $this, 'enqueue_script' ) );
+			add_action( 'zerospam_woocommerce_registration_scripts', array( $this, 'enqueue_script' ) );
 			add_filter(
 				'zerospam_memberpress_registration_scripts',
 				function( $scripts ) {
@@ -67,6 +68,7 @@ class DavidWalsh {
 			add_filter( 'zerospam_preprocess_memberpress_registration', array( $this, 'validate_post' ), 10, 3 );
 			add_filter( 'zerospam_preprocess_memberpress_login', array( $this, 'validate_post' ), 10, 3 );
 			add_filter( 'zerospam_preprocess_mailchimp4wp', array( $this, 'validate_post' ), 10, 3 );
+			add_filter( 'zerospam_process_woocommerce_registration', array( $this, 'validate_post' ), 10, 3 );
 		}
 	}
 

--- a/modules/woocommerce/class-woocommerce.php
+++ b/modules/woocommerce/class-woocommerce.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Zero Spam for WordPress WooCommerce Module
+ *
+ * @package ZeroSpam
+ */
+
+namespace ZeroSpam\Modules\WooCommerce;
+
+// Security Note: Blocks direct access to the plugin PHP files.
+defined( 'ABSPATH' ) || die();
+
+/**
+ * Zero Spam WooCommerce Module Class
+ */
+class WooCommerce {
+	/**
+	 * Class constructor
+	 */
+	public function __construct() {
+		add_action( 'init', array( $this, 'init' ) );
+	}
+
+	/**
+	 * Register the Zero Spam detection types
+	 *
+	 * @param array $types Array of available detection types.
+	 */
+	public function types( $types ) {
+		$types['woocommerce_registration'] = __( 'WooCommerce Registration', 'zero-spam' );
+
+		return $types;
+	}
+
+	/**
+	 * Register the Zero Spam admin setting sections
+	 *
+	 * @param array $sections Array of admin setting sections.
+	 */
+	public function sections( $sections ) {
+		$sections['woocommerce'] = array(
+			'title' => __( 'WooCommerce Integration', 'zero-spam' ),
+		);
+
+		return $sections;
+	}
+
+	/**
+	 * Register the Zero Spam admin settings for this module
+	 *
+	 * @param array $settings Array of available settings.
+	 * @param array $options  Array of saved database options.
+	 */
+	public function settings( $settings, $options ) {
+		$settings['verify_woocommerce_registrations'] = array(
+			'title'       => __( 'Protect Registrations', 'zero-spam' ),
+			'section'     => 'woocommerce',
+			'type'        => 'checkbox',
+			'options'     => array(
+				'enabled' => __( 'Monitor WooCommerce registrations for malicious or automated spambots.', 'zero-spam' ),
+			),
+			'value'       => ! empty( $options['verify_woocommerce_registrations'] ) ? 'enabled' : false,
+			'recommended' => 'enabled',
+		);
+
+		$message = __( 'Your IP has been flagged as spam/malicious.', 'zero-spam' );
+
+		$settings['woocommerce_registration_spam_message'] = array(
+			'title'       => __( 'Spam/Malicious Message', 'zero-spam' ),
+			'desc'        => __( 'When WooCommerce registration protection is enabled, the message displayed to the user when a registration has been detected as spam/malicious.', 'zero-spam' ),
+			'section'     => 'woocommerce',
+			'type'        => 'text',
+			'field_class' => 'large-text',
+			'placeholder' => $message,
+			'value'       => ! empty( $options['registration_spam_message'] ) ? $options['registration_spam_message'] : $message,
+			'recommended' => $message,
+		);
+
+		$settings['log_blocked_woocommerce_registrations'] = array(
+			'title'       => __( 'Log Blocked Registrations', 'zero-spam' ),
+			'section'     => 'woocommerce',
+			'type'        => 'checkbox',
+			'desc'        => wp_kses(
+				__( 'Enables logging blocked WooCommerce registrations. <strong>Recommended for enhanced protection.</strong>', 'zero-spam' ),
+				array( 'strong' => array() )
+			),
+			'options'     => array(
+				'enabled' => __( 'Enabled', 'zero-spam' ),
+			),
+			'value'       => ! empty( $options['log_blocked_registrations'] ) ? 'enabled' : false,
+			'recommended' => 'enabled',
+		);
+
+		return $settings;
+	}
+
+	/**
+	 * Fires after WordPress has finished loading but before any headers are sent.
+	 */
+	public function init() {
+		add_filter( 'zerospam_setting_sections', array( $this, 'sections' ) );
+		add_filter( 'zerospam_settings', array( $this, 'settings' ), 10, 2 );
+		add_filter( 'zerospam_types', array( $this, 'types' ), 10, 1 );
+
+		if (
+			'enabled' === \ZeroSpam\Core\Settings::get_settings( 'verify_woocommerce_registrations' ) &&
+			\ZeroSpam\Core\Access::process()
+		) {
+			add_action( 'woocommerce_register_form', array( $this, 'honeypot' ) );
+			add_action( 'woocommerce_register_form', array( $this, 'scripts' ) );
+			add_action( 'woocommerce_register_post', array( $this, 'process_registration' ), 10, 3 );
+		}
+	}
+
+	/**
+	 * Adds the 'honeypot' field to the WooCommerce registration form
+	 */
+	public function honeypot() {
+		woocommerce_form_field(
+			\ZeroSpam\Core\Utilities::get_honeypot(),
+			array(
+				'type'  => 'hidden',
+				'class' => array( 'zero-spam-hidden' ),
+			)
+		);
+	}
+
+	/**
+	 * Load the scripts
+	 */
+	public function scripts() {
+		do_action( 'zerospam_woocommerce_registration_scripts' );
+	}
+
+	/**
+	 * Preprocess registrations
+	 *
+	 * @param string $username Registration username.
+	 * @param string $email    Registration email address.
+	 * @param string $errors   WooCommerce error object.
+	 */
+	public function process_registration( $username, $email, $errors ) {
+		// Get all posted form fields.
+		// @codingStandardsIgnoreLine
+		$data = \ZeroSpam\Core\Utilities::sanitize_array( $_POST );
+
+		// Get the WooCommerce registration spam message.
+		$spam_message = \ZeroSpam\Core\Utilities::detection_message( 'woocommerce_registration_spam_message' );
+
+		// Create the details array for logging & sharing data.
+		$details = array(
+			'username' => $username,
+			'email'    => $email,
+			'data'     => $data,
+			'type'     => 'woocommerce_registration',
+		);
+
+		// Create the validation errors array.
+		$validation_errors = array();
+
+		// Check Zero Spam's honeypot field.
+		$honeypot_field_name = \ZeroSpam\Core\Utilities::get_honeypot();
+		if ( isset( $data[ $honeypot_field_name ] ) && ! empty( $data[ $honeypot_field_name ] ) ) {
+			// Failed the honeypot check.
+			$validation_errors[] = 'honeypot';
+		}
+
+		// Check blocked email domains.
+		if ( \ZeroSpam\Core\Utilities::is_email_domain_blocked( $email ) ) {
+			// Email domain has been blocked.
+			$validation_errors[] = 'blocked_email_domain';
+		}
+
+		// Fire hook for additional validation (ex. David Walsh script).
+		$filtered_errors = apply_filters( 'zerospam_process_woocommerce_registration', array(), $data, 'woocommerce_registration_spam_message' );
+
+		if ( ! empty( $filtered_errors ) ) {
+			foreach ( $filtered_errors as $key => $message ) {
+				$validation_errors[] = str_replace( 'zerospam_', '', $key );
+			}
+		}
+
+		// Check for validation errors, then log & share if enabled.
+		if ( ! empty( $validation_errors ) ) {
+			// Failed validations, log & send details if enabled.
+			foreach ( $validation_errors as $key => $fail ) {
+				$details['failed'] = $fail;
+
+				// Log the detection if enabled.
+				if ( 'enabled' === \ZeroSpam\Core\Settings::get_settings( 'log_blocked_woocommerce_registrations' ) ) {
+					\ZeroSpam\Includes\DB::log( 'woocommerce_registration', $details );
+				}
+
+				// Share the detection if enabled.
+				if ( 'enabled' === \ZeroSpam\Core\Settings::get_settings( 'share_data' ) ) {
+					do_action( 'zerospam_share_detection', $details );
+				}
+			}
+
+			// Add the spam message to the WooCommerce errors object.
+			$errors->add( 'zerospam_error', $spam_message );
+		}
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://www.zerospam.org/subscribe/
 Requires at least: 5.2
 Tested up to: 5.9
 Requires PHP: 7.3
-Stable tag: 5.2.12
+Stable tag: 5.2.13
 License: GNU GPLv3
 License URI: https://choosealicense.com/licenses/gpl-3.0/
 
@@ -41,6 +41,7 @@ Quit forcing people to answer questions or confusing captchas to prove they're n
 * [Fluent Forms](https://wordpress.org/plugins/fluentform/) submissions
 * [MemberPress](https://memberpress.com/) registrations
 * [Mailchimp for WordPress](https://wordpress.org/plugins/mailchimp-for-wp/) submissions
+* [WooCommerce](https://wordpress.org/plugins/woocommerce/) registrations
 * and can be easily integrated into any existing theme or plugin
 
 Zero Spam for WordPress is great at blocking spam &mdash; as a site owner there's more you can do to [stop WordPress spam](https://www.benmarshall.me/stop-wordpress-spam/) in its tracks.
@@ -102,6 +103,10 @@ If hosting with Pantheon, see their [known issues page](https://pantheon.io/docs
 5. Zero Spam for WordPress settings
 
 == Changelog ==
+
+= v5.2.13 =
+
+* feat(woocommerce): added support for woocommerce registrations
 
 = v5.2.12 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -106,7 +106,7 @@ If hosting with Pantheon, see their [known issues page](https://pantheon.io/docs
 
 = v5.2.13 =
 
-* feat(woocommerce): added support for woocommerce registrations
+* feat(woocommerce): added support for woocommerce registrations, resolves #306
 
 = v5.2.12 =
 

--- a/wordpress-zero-spam.php
+++ b/wordpress-zero-spam.php
@@ -13,7 +13,7 @@
  * Plugin Name:       Zero Spam for WordPress
  * Plugin URI:        https://www.highfivery.com/projects/zero-spam/
  * Description:       Tired of all the ineffective WordPress anti-spam & security plugins? Zero Spam for WordPress makes blocking spam &amp; malicious activity a cinch. <strong>Just activate, configure, and say goodbye to spam.</strong>
- * Version:           5.2.12
+ * Version:           5.2.13
  * Requires at least: 5.2
  * Requires PHP:      7.3
  * Author:            Highfivery LLC
@@ -31,7 +31,7 @@ defined( 'ABSPATH' ) || die();
 define( 'ZEROSPAM', __FILE__ );
 define( 'ZEROSPAM_PATH', plugin_dir_path( ZEROSPAM ) );
 define( 'ZEROSPAM_PLUGIN_BASE', plugin_basename( ZEROSPAM ) );
-define( 'ZEROSPAM_VERSION', '5.2.12' );
+define( 'ZEROSPAM_VERSION', '5.2.13' );
 
 if ( defined( 'ZEROSPAM_DEVELOPMENT_URL' ) ) {
 	define( 'ZEROSPAM_URL', ZEROSPAM_DEVELOPMENT_URL );


### PR DESCRIPTION
This adds support for WooCommerce registrations.

Need some QA to ensure it doesn't interfere with core WordPress registrations & doesn't cause issues with instances where the WooCommerce registration form is displayed:

1. Login/registration page
2. Checkout page